### PR TITLE
Ensure that file systems files wins over those in jars

### DIFF
--- a/src/main/kotlin/no/item/xp/plugin/util/TargetFile.kt
+++ b/src/main/kotlin/no/item/xp/plugin/util/TargetFile.kt
@@ -24,6 +24,8 @@ fun getTargetFile(
 
 fun simpleFilePath(file: File): String = file.canonicalPath.substringAfter("""resources${File.separatorChar}""")
 
-fun normalizeFilePath(file: File) = file.absolutePath.replace(File.separatorChar, '/')
+fun normalizeFilePath(filePath: String): String = filePath.replace(File.separatorChar, '/')
+
+fun normalizeFilePath(file: File): String = normalizeFilePath(file.absolutePath)
 
 fun concatFileName(vararg parts: String): String = parts.joinToString(File.separator) { it }

--- a/src/main/kotlin/no/item/xp/plugin/util/XmlFileInJar.kt
+++ b/src/main/kotlin/no/item/xp/plugin/util/XmlFileInJar.kt
@@ -1,6 +1,13 @@
 package no.item.xp.plugin.util
 
+import java.io.InputStream
+import java.nio.file.Paths
 import java.util.jar.JarFile
 import java.util.zip.ZipEntry
+import kotlin.io.path.nameWithoutExtension
 
-data class XmlFileInJar(val jarFile: JarFile, val entry: ZipEntry)
+data class XmlFileInJar(val jarFile: JarFile, val entry: ZipEntry) {
+  val nameWithoutExtension = Paths.get(this.entry.name).fileName.nameWithoutExtension
+
+  fun inputStream(): InputStream = this.jarFile.getInputStream(this.entry)
+}


### PR DESCRIPTION
When XML-files with the same name exists both in the project and in a jar-file. Ensure that the project-version of the file is used for generating the type.

Closes to: #64