### PR TITLE
Make output conform to prettier defaults

### DIFF
--- a/src/main/kotlin/no/item/xp/plugin/GenerateCodeTask.kt
+++ b/src/main/kotlin/no/item/xp/plugin/GenerateCodeTask.kt
@@ -101,10 +101,10 @@ open class GenerateCodeTask
 
       createContentTypeIndexFile(rootOutputDir, appName)
 
-      createComponentIndexFile(rootOutputDir, appName, "parts", xmlFilesInJars, "XpPartMap")
-      createComponentIndexFile(rootOutputDir, appName, "layouts", xmlFilesInJars, "XpLayoutMap")
-      createComponentIndexFile(rootOutputDir, appName, "pages", xmlFilesInJars, "XpPageMap")
-      createComponentIndexFile(rootOutputDir, appName, "mixins", xmlFilesInJars)
+      createComponentIndexFile(rootOutputDir, appName, "parts", xmlFilesInJars, singleQuote, "XpPartMap")
+      createComponentIndexFile(rootOutputDir, appName, "layouts", xmlFilesInJars, singleQuote, "XpLayoutMap")
+      createComponentIndexFile(rootOutputDir, appName, "pages", xmlFilesInJars, singleQuote, "XpPageMap")
+      createComponentIndexFile(rootOutputDir, appName, "mixins", xmlFilesInJars, singleQuote)
 
       createXDataIndexFile(rootOutputDir, appName, xmlFilesInJars)
     }
@@ -131,13 +131,12 @@ open class GenerateCodeTask
           { right ->
             val fileContent = renderTypeModelAsTypeScript(right)
 
-            var targetFilePath = Paths.get(rootOutputDir.absolutePath, fileInJar.entry.name)
-            targetFilePath = Paths.get(targetFilePath.parent.toString(), "index.d.ts")
+            val targetFilePath = Paths.get(rootOutputDir.absolutePath, fileInJar.entry.name)
+            val indexFilePath = Paths.get(targetFilePath.parent.toString(), "index.d.ts")
+            val targetFile = File(indexFilePath.toUri())
+
+            writeTargetFile(targetFile, fileContent, prependText, singleQuote)
             logger.lifecycle("Updated file: ${targetFilePath.toUri()}")
-            val targetFile = File(targetFilePath.toUri())
-            targetFile.parentFile.mkdirs()
-            targetFile.createNewFile()
-            targetFile.writeText(fileContent, Charsets.UTF_8)
           },
         )
     }
@@ -156,9 +155,7 @@ open class GenerateCodeTask
       if (files.isNotEmpty()) {
         val fileContent = renderGlobalContentTypeMap(files, appName)
         val targetFile = File(rootOutputDir.absolutePath + "/site/content-types/index.d.ts")
-        targetFile.parentFile.mkdirs()
-        targetFile.createNewFile()
-        targetFile.writeText(prependText + "\n" + fileContent, Charsets.UTF_8)
+        writeTargetFile(targetFile, fileContent, prependText, singleQuote)
         logger.lifecycle("Updated file: ${Path.of(targetFile.toURI()).toUri()}")
       }
     }
@@ -168,6 +165,7 @@ open class GenerateCodeTask
       appName: String?,
       componentTypeName: String,
       xmlFilesInJars: List<XmlFileInJar>,
+      singleQuote: Boolean,
       interfaceName: String? = null,
     ) {
       val xmlFiles =
@@ -185,10 +183,8 @@ open class GenerateCodeTask
       if (files.isNotEmpty()) {
         val fileContent = renderGlobalComponentMap(files, appName, interfaceName)
         val targetFile = File(concatFileName(rootOutputDir.absolutePath, "site", componentTypeName, "index.d.ts"))
-        targetFile.parentFile.mkdirs()
-        targetFile.createNewFile()
-        targetFile.writeText(prependText + "\n" + fileContent, Charsets.UTF_8)
-        logger.lifecycle("Updated file: ${Path.of(targetFile.toURI()).toUri()}")
+        writeTargetFile(targetFile, fileContent, prependText, singleQuote)
+        logger.lifecycle("Updated file: ${Path.of(targetFile.toURI()).toUri()} singleQuote = $singleQuote")
       }
     }
 
@@ -212,9 +208,7 @@ open class GenerateCodeTask
       if (files.isNotEmpty()) {
         val fileContent = renderGlobalXDataMap(files, appName)
         val targetFile = File(rootOutputDir.absolutePath + "/site/x-data/index.d.ts")
-        targetFile.parentFile.mkdirs()
-        targetFile.createNewFile()
-        targetFile.writeText(prependText + "\n" + fileContent, Charsets.UTF_8)
+        writeTargetFile(targetFile, fileContent, prependText, singleQuote)
         logger.lifecycle("Updated file: ${Path.of(targetFile.toURI()).toUri()}")
       }
     }

--- a/src/main/kotlin/no/item/xp/plugin/GenerateCodeTask.kt
+++ b/src/main/kotlin/no/item/xp/plugin/GenerateCodeTask.kt
@@ -184,7 +184,7 @@ open class GenerateCodeTask
         val fileContent = renderGlobalComponentMap(files, appName, interfaceName)
         val targetFile = File(concatFileName(rootOutputDir.absolutePath, "site", componentTypeName, "index.d.ts"))
         writeTargetFile(targetFile, fileContent, prependText, singleQuote)
-        logger.lifecycle("Updated file: ${Path.of(targetFile.toURI()).toUri()} singleQuote = $singleQuote")
+        logger.lifecycle("Updated file: ${Path.of(targetFile.toURI()).toUri()}")
       }
     }
 

--- a/src/main/kotlin/no/item/xp/plugin/GenerateTypeScriptWorkAction.kt
+++ b/src/main/kotlin/no/item/xp/plugin/GenerateTypeScriptWorkAction.kt
@@ -10,6 +10,7 @@ import no.item.xp.plugin.renderers.ts.renderTypeModelAsTypeScript
 import no.item.xp.plugin.util.concatFileName
 import no.item.xp.plugin.util.parseXml
 import no.item.xp.plugin.util.simpleFilePath
+import no.item.xp.plugin.util.writeTargetFile
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.logging.Logging
 import org.gradle.api.provider.ListProperty
@@ -55,25 +56,15 @@ abstract class GenerateTypeScriptWorkAction : WorkAction<CodegenWorkParameters> 
             logger.error(it.message)
           },
           {
-            var fileContent =
+            val fileContent =
               if (file.absolutePath.endsWith(concatFileName("resources", "site", "site.xml"))) {
                 renderSiteConfig(it)
               } else {
                 renderTypeModelAsTypeScript(it)
               }
 
-            if (parameters.getSingleQuote().get()) {
-              fileContent = fileContent.replace("\"", "'")
-            }
+            writeTargetFile(targetFile, fileContent, parameters.getPrependText().get(), parameters.getSingleQuote().get())
 
-            val prependText = parameters.getPrependText().get()
-            if (prependText.isNotEmpty()) {
-              fileContent = prependText + "\n" + fileContent
-            }
-
-            targetFile.parentFile.mkdirs()
-            targetFile.createNewFile()
-            targetFile.writeText(fileContent, Charsets.UTF_8)
             logger.lifecycle("Updated file: ${Path.of(targetFile.absoluteFile.toURI()).toUri()}")
           },
         )

--- a/src/main/kotlin/no/item/xp/plugin/renderers/RenderGlobalComponentMap.kt
+++ b/src/main/kotlin/no/item/xp/plugin/renderers/RenderGlobalComponentMap.kt
@@ -10,7 +10,7 @@ fun renderGlobalComponentMap(
   val importList =
     filesNames.joinToString("\n") { fileName ->
       """export type ${getInterfaceName(fileName)} = import("./$fileName").${getInterfaceName(fileName)};"""
-    }
+    } + "\n"
 
   return if (interfaceName == null || appName == null) {
     importList
@@ -22,7 +22,6 @@ fun renderGlobalComponentMap(
 
     """
     #$importList
-    #
     #declare global {
     #  interface $interfaceName {
     #$fieldList

--- a/src/main/kotlin/no/item/xp/plugin/renderers/ts/RenderTypeModelAsTypeScript.kt
+++ b/src/main/kotlin/no/item/xp/plugin/renderers/ts/RenderTypeModelAsTypeScript.kt
@@ -8,6 +8,6 @@ fun renderTypeModelAsTypeScript(model: ObjectTypeModel): String {
   return """
     #export type ${getInterfaceName(model.nameWithoutExtension)} = {
     #$fieldList
-    #}
+    #};
     #""".trimMargin("#")
 }

--- a/src/main/kotlin/no/item/xp/plugin/util/TargetFile.kt
+++ b/src/main/kotlin/no/item/xp/plugin/util/TargetFile.kt
@@ -8,6 +8,36 @@ val IS_MIXIN = "^.*site/mixins.*\$".toRegex(RegexOption.IGNORE_CASE)
 val IS_PART = "^.*site/parts.*\$".toRegex(RegexOption.IGNORE_CASE)
 val IS_PAGE = "^.*site/pages.*\$".toRegex(RegexOption.IGNORE_CASE)
 
+fun writeTargetFile(
+  targetFile: File,
+  fileContent: String,
+  prependText: String,
+  singleQuote: Boolean,
+) {
+  val content = prependWithText(replaceWithSingleQuotes(fileContent, singleQuote), prependText)
+  targetFile.parentFile.mkdirs()
+  targetFile.createNewFile()
+  targetFile.writeText(content, Charsets.UTF_8)
+}
+
+private fun replaceWithSingleQuotes(
+  content: String,
+  singleQuote: Boolean,
+): String =
+  if (singleQuote) {
+    content.replace(
+      "\"",
+      "'",
+    )
+  } else {
+    content
+  }
+
+private fun prependWithText(
+  content: String,
+  prependText: String,
+): String = if (prependText.isEmpty()) content else prependText + "\n" + content
+
 fun getTargetDirectory(
   inputFile: File,
   rootDir: File,

--- a/src/test/kotlin/no/item/xp/plugin/renderers/ts/RenderObjectTypeModelTest.kt
+++ b/src/test/kotlin/no/item/xp/plugin/renderers/ts/RenderObjectTypeModelTest.kt
@@ -50,7 +50,7 @@ class RenderObjectTypeModelTest {
       #   * Favourite color
       #   */
       #  favouriteColor: "red" | "green" | "blue";
-      #}
+      #};
       #
       """.trimMargin(
         //language=

--- a/src/test/kotlin/no/item/xp/plugin/renderers/ts/RenderOptionSetFieldTest.kt
+++ b/src/test/kotlin/no/item/xp/plugin/renderers/ts/RenderOptionSetFieldTest.kt
@@ -76,7 +76,7 @@ class RenderOptionSetFieldTest {
       #          articleList?: Array<string> | string;
       #        };
       #      };
-      #}
+      #};
       #""".trimMargin(
         //language=
         "#",
@@ -149,7 +149,7 @@ class RenderOptionSetFieldTest {
       #      articleList?: Array<string> | string;
       #    };
       #  };
-      #}
+      #};
       #""".trimMargin(
         //language=
         "#",
@@ -230,7 +230,7 @@ class RenderOptionSetFieldTest {
       #        };
       #      }
       #  >;
-      #}
+      #};
       #""".trimMargin(
         //language=
         "#",


### PR DESCRIPTION
 - Add newline at the end of index-files without global interface
 - Add semicolon after type definitions
 - Ensure that "singleQuote" setting always is respected in all file writes

Closes to: #66